### PR TITLE
Add --context parameter to allow the definition of an initial url path

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,11 @@ docker run -d -p 80:8043 -v path/to/website:/srv/http --name goStatic pierrezemb
 
 ```
 ./goStatic --help
-Usage of ./goStatic:
+Usage of /goStatic:
   -append-header HeaderName:Value
         HTTP response header, specified as HeaderName:Value that should be added to all responses.
+  -context string
+        The 'context' path on which files are served, e.g. 'doc' will serve the files at 'http://localhost:<port>/doc/'
   -default-user-basic-auth string
         Define the user (default "gopher")
   -enable-basic-auth

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 var (
 	// Def of flags
 	portPtr                  = flag.Int("port", 8043, "The listening port")
+	context                  = flag.String("context", "", "The 'context' path on which files are served, e.g. 'doc' will serve the files at 'http://localhost:<port>/doc/'")
 	path                     = flag.String("path", "/srv/http", "The path for the static files")
 	headerFlag               = flag.String("append-header", "", "HTTP response header, specified as `HeaderName:Value` that should be added to all responses.")
 	basicAuth                = flag.Bool("enable-basic-auth", false, "Enable basic auth. By default, password are randomly generated. Use --set-basic-auth to set it.")
@@ -46,8 +47,14 @@ func main() {
 	}
 
 	port := ":" + strconv.FormatInt(int64(*portPtr), 10)
-
+	
 	handler := http.FileServer(http.Dir(*path))
+	
+	pathPrefix := "/";
+	if len(*context) > 0 {
+		pathPrefix = "/"+*context+"/"
+		handler = http.StripPrefix(pathPrefix, handler)
+	}
 
 	if *basicAuth {
 		log.Println("Enabling Basic Auth")
@@ -73,8 +80,8 @@ func main() {
 		}
 	}
 
-	http.Handle("/", handler)
+	http.Handle(pathPrefix, handler)
 
-	log.Printf("Listening at 0.0.0.0%v...", port)
+	log.Printf("Listening at 0.0.0.0%v %v...", port, pathPrefix)
 	log.Fatalln(http.ListenAndServe(port, nil))
 }


### PR DESCRIPTION
Hello,

this patch provides a way to define the 'context path' of the file server.

I required this to sync the URL path part between a load balancer and and a container with this image hosting some documentation. The external path was /documents/ and the load balancer was not able to strip this path from the request so I required this patch to reflect this context name inside the container.

Maybe this is of interest for others, too.