### PR TITLE
Fix a warning with getaddrinfo while compiling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:latest as builder
 WORKDIR /go/src/github.com/PierreZ/goStatic
 COPY . .
 
-RUN GOARCH=amd64 GOOS=linux go build  -ldflags "-linkmode external -extldflags -static -w"
+RUN GOARCH=amd64 GOOS=linux go build -tags netgo -installsuffix netgo -ldflags "-linkmode external -extldflags -static -w"
 
 # stage 1
 FROM centurylink/ca-certs


### PR DESCRIPTION
add netgo to the build to fix this ugly warning:
```
/tmp/go-link-148332811/000004.o: In function `_cgo_f7895c2c5a3a_C2func_getaddrinfo':                                                                                                        
/tmp/go-build/cgo-gcc-prolog:46: warning: Using 'getaddrinfo' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
```
Interestingly the Image size decreases with that fix by some KB.

I got the idea from here: https://github.com/opencontainers/runc/pull/1577