### PR TITLE
Adds https promotion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,5 @@ FROM scratch
 WORKDIR /
 COPY --from=builder /go/src/github.com/PierreZ/goStatic/bin/ .
 USER appuser
-ENTRYPOINT ["/goStatic"]
+ENTRYPOINT ["/goStatic","-enable-logging","-https-promote"]
  

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Yeah, decided to drop support of unsecured HTTPS. Two-years ago, when I started 
  * A fully static web server in 6MB
  * No framework
  * Web server built for Docker
- * Can generate certificate on its own
+ * Can generate the certificate on its own
  * Light container
  * More secure than official images (see below)
  * Log enabled
@@ -23,7 +23,7 @@ Because the official Golang image is wayyyy too big (around 1/2Gb as you can see
 [![](https://badge.imagelayers.io/golang:latest.svg)](https://imagelayers.io/?images=golang:latest 'Get your own badge on imagelayers.io')
 
 For me, the whole point of containers is to have a light container...
-Many links should provide you with additionnal info to see my point of view:
+Many links should provide you with additional info to see my point of view:
 
  * [Over 30% of Official Images in Docker Hub Contain High Priority Security Vulnerabilities](http://www.banyanops.com/blog/analyzing-docker-hub/)
  * [Create The Smallest Possible Docker Container](http://blog.xebia.com/2014/07/04/create-the-smallest-possible-docker-container/)
@@ -68,7 +68,7 @@ Usage of /goStatic:
 
 #### Fallback
 
-The fallback option is principally useful for single page applications (SPAs) where the browser may request a file, but where part of the path is in fact an internal route in the application, not a file on disk. goStatic supports two possible usages of this option:
+The fallback option is principally useful for single-page applications (SPAs) where the browser may request a file, but where part of the path is in fact an internal route in the application, not a file on disk. goStatic supports two possible usages of this option:
 
 1. Using an absolute path so that all not found requests resolve to the same file
 2. Using a relative file, which searches up the tree for the specified file

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Yeah, decided to drop support of unsecured HTTPS. Two-years ago, when I started 
  * Log enabled
 
 ### Why?
-Because the official Golang image is wayyyy too big (around 1/2Gb as you can see below) and could be unsecure.
+Because the official Golang image is wayyyy too big (around 1/2Gb as you can see below) and could be insecure.
 
 [![](https://badge.imagelayers.io/golang:latest.svg)](https://imagelayers.io/?images=golang:latest 'Get your own badge on imagelayers.io')
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ Usage of /goStatic:
         The listening port (default 8043)
   -set-basic-auth string
         Define the basic auth. Form must be user:password
+  -https-promote
+        Connections to http: are redirected to https:
+  -enable-logging
+        Writes a simple log entry for requests to the server
 ```
 
 #### Fallback

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ var (
 	setBasicAuth             = flag.String("set-basic-auth", "", "Define the basic auth. Form must be user:password")
 	defaultUsernameBasicAuth = flag.String("default-user-basic-auth", "gopher", "Define the user")
 	sizeRandom               = flag.Int("password-length", 16, "Size of the randomized password")
+	logRequest               = flag.Bool("enable-logging", false, "Enable log request")
 
 	username string
 	password string
@@ -65,6 +66,15 @@ func (w *gzipResponseWriter) Write(b []byte) (int, error) {
 	return w.Writer.Write(b)
 }
 
+func handleReq(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if *logRequest {
+			log.Println(r.Method, r.URL.Path)
+		}
+		h.ServeHTTP(w, r)
+	})
+}
+
 func main() {
 
 	flag.Parse()
@@ -85,7 +95,7 @@ func main() {
 		}
 	}
 
-	handler := http.FileServer(fileSystem)
+	handler := handleReq(http.FileServer(fileSystem))
 
 	pathPrefix := "/"
 	if len(*context) > 0 {

--- a/main.go
+++ b/main.go
@@ -69,7 +69,7 @@ func (w *gzipResponseWriter) Write(b []byte) (int, error) {
 
 func handleReq(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get("X-Forwarded-Proto") == "http" {
+		if *httpsPromote && r.Header.Get("X-Forwarded-Proto") == "http" {
 			http.Redirect(w, r, "https://"+r.Host+r.RequestURI, http.StatusMovedPermanently)
 			if *logRequest {
 				log.Println(301, r.Method, r.URL.Path)

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ var (
 	defaultUsernameBasicAuth = flag.String("default-user-basic-auth", "gopher", "Define the user")
 	sizeRandom               = flag.Int("password-length", 16, "Size of the randomized password")
 	logRequest               = flag.Bool("enable-logging", false, "Enable log request")
+	httpsPromote             = flag.Bool("https-promote", false, "All HTTP requests should be redirected to HTTPS")
 
 	username string
 	password string
@@ -68,6 +69,13 @@ func (w *gzipResponseWriter) Write(b []byte) (int, error) {
 
 func handleReq(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Forwarded-Proto") == "http" {
+			http.Redirect(w, r, "https://"+r.Host+r.RequestURI, http.StatusMovedPermanently)
+			if *logRequest {
+				log.Println(301, r.Method, r.URL.Path)
+			}
+			return
+		}
 		if *logRequest {
 			log.Println(r.Method, r.URL.Path)
 		}


### PR DESCRIPTION
I'm PRing this in case you want to incorporate it. It includes the PR for logging, and then adds a -https-promote option so that any incoming traffic which has been forwarded to it with X-FORWARDER-PROTO set to http is redirected to the https version of the host/URI.

Background: Fly applications run behind proxys and forwarder sending traffic from the Anycast edge to applications. They manage the http/https element of the connection. But, they don't currently automatically force http connections to https, HSTS style. This change enables that.