### PR TITLE
Add debug symbol stripping and binary packing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,11 @@ FROM golang:latest as builder
 WORKDIR /go/src/github.com/PierreZ/goStatic
 COPY . .
 RUN mkdir ./bin && \
-    CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -tags netgo -installsuffix netgo -o ./bin/goStatic && \
+    apt-get update && apt-get install -y upx && \
+    CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -ldflags="-s" -tags netgo -installsuffix netgo -o ./bin/goStatic && \
     mkdir ./bin/etc && \
     ID=$(shuf -i 100-9999 -n 1) && \
+    upx -9 ./bin/goStatic && \
     echo $ID && \
     echo "appuser:x:$ID:$ID::/sbin/nologin:/bin/false" > ./bin/etc/passwd && \
     echo "appgroup:x:$ID:appuser" > ./bin/etc/group

--- a/Dockerfile.arm5
+++ b/Dockerfile.arm5
@@ -3,9 +3,11 @@ FROM golang:latest as builder
 WORKDIR /go/src/github.com/PierreZ/goStatic
 COPY . .
 RUN mkdir ./bin && \
-    CGO_ENABLED=0 GOARCH=arm GOARM=5 GOOS=linux go build -tags netgo -installsuffix netgo -o ./bin/goStatic && \
+    apt-get update && apt-get install -y upx && \
+    CGO_ENABLED=0 GOARCH=arm GOARM=5 GOOS=linux go build -ldflags="-s" -tags netgo -installsuffix netgo -o ./bin/goStatic && \
     mkdir ./bin/etc && \
     ID=$(shuf -i 100-9999 -n 1) && \
+    upx -9 ./bin/goStatic && \
     echo $ID && \
     echo "appuser:x:$ID:$ID::/sbin/nologin:/bin/false" > ./bin/etc/passwd && \
     echo "appgroup:x:$ID:appuser" > ./bin/etc/group

--- a/Dockerfile.arm6
+++ b/Dockerfile.arm6
@@ -3,9 +3,11 @@ FROM golang:latest as builder
 WORKDIR /go/src/github.com/PierreZ/goStatic
 COPY . .
 RUN mkdir ./bin && \
-    CGO_ENABLED=0 GOARCH=arm GOARM=6 GOOS=linux go build -tags netgo -installsuffix netgo -o ./bin/goStatic && \
+    apt-get update && apt-get install -y upx && \
+    CGO_ENABLED=0 GOARCH=arm GOARM=6 GOOS=linux go build -ldflags="-s" -tags netgo -installsuffix netgo -o ./bin/goStatic && \
     mkdir ./bin/etc && \
     ID=$(shuf -i 100-9999 -n 1) && \
+    upx -9 ./bin/goStatic && \
     echo $ID && \
     echo "appuser:x:$ID:$ID::/sbin/nologin:/bin/false" > ./bin/etc/passwd && \
     echo "appgroup:x:$ID:appuser" > ./bin/etc/group

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -3,9 +3,11 @@ FROM golang:latest as builder
 WORKDIR /go/src/github.com/PierreZ/goStatic
 COPY . .
 RUN mkdir ./bin && \
-    CGO_ENABLED=0 GOARCH=arm64 GOOS=linux go build -tags netgo -installsuffix netgo -o ./bin/goStatic && \
+    apt-get update && apt-get install -y upx && \
+    CGO_ENABLED=0 GOARCH=arm64 GOOS=linux go build -ldflags="-s" -tags netgo -installsuffix netgo -o ./bin/goStatic && \
     mkdir ./bin/etc && \
     ID=$(shuf -i 100-9999 -n 1) && \
+    upx -9 ./bin/goStatic && \
     echo $ID && \
     echo "appuser:x:$ID:$ID::/sbin/nologin:/bin/false" > ./bin/etc/passwd && \
     echo "appgroup:x:$ID:appuser" > ./bin/etc/group

--- a/Dockerfile.arm7
+++ b/Dockerfile.arm7
@@ -3,9 +3,11 @@ FROM golang:latest as builder
 WORKDIR /go/src/github.com/PierreZ/goStatic
 COPY . .
 RUN mkdir ./bin && \
-    CGO_ENABLED=0 GOARCH=arm GOARM=7 GOOS=linux go build -tags netgo -installsuffix netgo -o ./bin/goStatic && \
+    apt-get update && apt-get install -y upx && \
+    CGO_ENABLED=0 GOARCH=arm GOARM=7 GOOS=linux go build -ldflags="-s" -tags netgo -installsuffix netgo -o ./bin/goStatic && \
     mkdir ./bin/etc && \
     ID=$(shuf -i 100-9999 -n 1) && \
+    upx -9 ./bin/goStatic && \
     echo $ID && \
     echo "appuser:x:$ID:$ID::/sbin/nologin:/bin/false" > ./bin/etc/passwd && \
     echo "appgroup:x:$ID:appuser" > ./bin/etc/group


### PR DESCRIPTION
This adds the `-s` linker flag when building the go binary (to strip debug symbols) which shaves off ~2MB of the resulting code. Additionally, it runs the binary output through an aggressive [upx](https://github.com/upx/upx) run. Here are the resulting Docker image sizes (which are pretty much just the sizes of the binaries in the scratch container).

```
➜  goStatic git:(master) ✗ docker image inspect gostatic | grep Size
        "Size": 1840942,
        "VirtualSize": 1840942,
➜  goStatic git:(master) ✗ docker image inspect gostatic:arm5 | grep Size
        "Size": 1702918,
        "VirtualSize": 1702918,
➜  goStatic git:(master) ✗ docker image inspect gostatic:arm6 | grep Size
        "Size": 1696290,
        "VirtualSize": 1696290,
➜  goStatic git:(master) ✗ docker image inspect gostatic:arm7 | grep Size
        "Size": 1693834,
        "VirtualSize": 1693834,
➜  goStatic git:(master) ✗ docker image inspect gostatic:arm64 | grep Size
        "Size": 1673671,
        "VirtualSize": 1673671,
```

Roughly they're all ~30% of the previous size but with a slight startup penalty (likely in the single milliseconds or lower) due to `upx` and the need to decompress the binary code sections in memory.