### PR TITLE
Removes outdated feature from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ Yeah, decided to drop support of unsecured HTTPS. Two-years ago, when I started 
  * A fully static web server in 6MB
  * No framework
  * Web server built for Docker
- * Can generate the certificate on its own
  * Light container
  * More secure than official images (see below)
  * Log enabled


### PR DESCRIPTION
The container does not create SSL Certs anymore.
Removed the corresponding entry from the README