### PR TITLE
replacing flags package to read from env variables, updating README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ Usage of ./goStatic:
         Enable basic auth. By default, password are randomly generated. Use --set-basic-auth to set it.
   -enable-health
         Enable health check endpoint. You can call /health to get a 200 response. Useful for Kubernetes, OpenFaas, etc.
-  -enable-logging
+  -log-level
+        default: info - What level of logging to run, debug logs all requests (error, warn, info, debug)
+  -enable-logging (Deprecated in favor of `-log-level debug` to log the requests)
         Enable log request
   -fallback string
         Default fallback file. Either absolute for a specific asset (/index.html), or relative to recursively resolve (index.html)
@@ -77,7 +79,34 @@ The fallback option is principally useful for single-page applications (SPAs) wh
 
 The second case is useful if you have multiple SPAs within the one filesystem. e.g., */* and */admin*.
 
+## Docker Usage
 
+To modify the docker image to use cmd line args, use the `entrypoint` directive in docker to supply the required arguments.
+
+You can also use environment variables to set the command arguments.  Note that if you supply both `entrypoint` cmd line args and environment variables, the cmd-line args will override your environment variables.
+
+**Important:** The environment variables are the exact same as the cmd line args, except they are uppercase, and the "-" is replaced with a "_".
+
+### Docker Compose Example
+
+```yaml
+---
+version: '3.7'
+
+services:
+  website:
+    image: pierrezemb/gostatic
+    hostname: website
+    container_name: website
+    volumes:
+      - /local-files/website/site/public:/srv/http
+    ports:
+      - 8043:8043
+    environment:
+      - LOG_LEVEL=debug
+    entrypoint: "/goStatic -fallback /404.html"
+
+```
 ## Build
 
 ### Docker images

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/PierreZ/goStatic
 
 go 1.16
 
-require github.com/rs/zerolog v1.26.1
+require (
+	github.com/namsral/flag v1.7.4-pre
+	github.com/rs/zerolog v1.26.1
+)

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
+github.com/namsral/flag v1.7.4-pre h1:b2ScHhoCUkbsq0d2C15Mv+VU8bl8hAXV8arnWiOHNZs=
+github.com/namsral/flag v1.7.4-pre/go.mod h1:OXldTctbM6SWH1K899kPZcf65KxJiD7MsceFUpB5yDo=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/rs/xid v1.3.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.26.1 h1:/ihwxqH+4z8UxyI70wM1z9yCvkWcfz/a3mj48k/Zngc=

--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"compress/gzip"
-	"flag"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -15,6 +14,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/namsral/flag"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )


### PR DESCRIPTION
This allows reading in `env` variables to set goStatic arguments.

Updated README with some more info.

Was not able to test this in Docker (not too familiar with the build process) but this does work locally on Windows when I tested it.