### PR TITLE
feat: username and password flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # goStatic [![Docker Pulls](https://img.shields.io/docker/pulls/pierrezemb/gostatic.svg?style=plastic)](https://hub.docker.com/r/pierrezemb/gostatic/) [![Docker Build](https://img.shields.io/docker/build/pierrezemb/gostatic.svg?style=plastic)](https://hub.docker.com/r/pierrezemb/gostatic/) [![Build Status](https://travis-ci.org/PierreZ/goStatic.svg?branch=master)](https://travis-ci.org/PierreZ/goStatic)  [![GoDoc](https://godoc.org/github.com/PierreZ/goStatic?status.svg)](https://godoc.org/github.com/PierreZ/goStatic)
+
 A really small, multi-arch, static web server for Docker
 
 ## The goal
+
 My goal is to create to smallest docker container for my web static files. The advantage of Go is that you can generate a fully static binary, so that you don't need anything else.
 
 ### Wait, I've been using old versions of GoStatic and things have changed!
@@ -9,15 +11,17 @@ My goal is to create to smallest docker container for my web static files. The a
 Yeah, decided to drop support of unsecured HTTPS. Two-years ago, when I started GoStatic, there was no automatic HTTPS available. Nowadays, thanks to Let's Encrypt, it's really easy to do so. If you need HTTPS, I recommend [caddy](https://caddyserver.com).
 
 ## Features
- * A fully static web server embedded in a `SCRATCH` image
- * No framework
- * Web server built for Docker
- * Light container
- * More secure than official images (see below)
- * Log enabled
- * Specify custom response headers per path and filetype [(info)](./docs/header-config.md) 
+
+* A fully static web server embedded in a `SCRATCH` image
+* No framework
+* Web server built for Docker
+* Light container
+* More secure than official images (see below)
+* Log enabled
+* Specify custom response headers per path and filetype [(info)](./docs/header-config.md)
 
 ## Why?
+
 Because the official Golang image is wayyyy too big (around 1/2Gb as you can see below) and could be insecure.
 
 [![](https://badge.imagelayers.io/golang:latest.svg)](https://imagelayers.io/?images=golang:latest 'Get your own badge on imagelayers.io')
@@ -25,19 +29,20 @@ Because the official Golang image is wayyyy too big (around 1/2Gb as you can see
 For me, the whole point of containers is to have a light container...
 Many links should provide you with additional info to see my point of view:
 
- * [Over 30% of Official Images in Docker Hub Contain High Priority Security Vulnerabilities](http://www.banyanops.com/blog/analyzing-docker-hub/)
- * [Create The Smallest Possible Docker Container](http://blog.xebia.com/2014/07/04/create-the-smallest-possible-docker-container/)
- * [Building Docker Images for Static Go Binaries](https://medium.com/@kelseyhightower/optimizing-docker-images-for-static-binaries-b5696e26eb07)
- * [Small Docker Images For Go Apps](https://www.ctl.io/developers/blog/post/small-docker-images-for-go-apps)
+* [Over 30% of Official Images in Docker Hub Contain High Priority Security Vulnerabilities](http://www.banyanops.com/blog/analyzing-docker-hub/)
+* [Create The Smallest Possible Docker Container](http://blog.xebia.com/2014/07/04/create-the-smallest-possible-docker-container/)
+* [Building Docker Images for Static Go Binaries](https://medium.com/@kelseyhightower/optimizing-docker-images-for-static-binaries-b5696e26eb07)
+* [Small Docker Images For Go Apps](https://www.ctl.io/developers/blog/post/small-docker-images-for-go-apps)
 
 ## How to use
-```
+
+```bash
 docker run -d -p 80:8043 -v path/to/website:/srv/http --name goStatic pierrezemb/gostatic
 ```
 
-## Usage 
+## Usage
 
-```
+```bash
 ./goStatic --help
 Usage of ./goStatic:
   -append-header HeaderName:Value
@@ -65,7 +70,11 @@ Usage of ./goStatic:
   -port int
         The listening port (default 8043)
   -set-basic-auth string
-        Define the basic auth. Form must be user:password
+        Define the basic auth user string. Form must be user:password
+  -basic-auth-user
+        Define the basic auth username
+  -basic-auth-pass
+        Define the basic auth password
 ```
 
 ### Fallback
@@ -77,10 +86,10 @@ The fallback option is principally useful for single-page applications (SPAs) wh
 
 The second case is useful if you have multiple SPAs within the one filesystem. e.g., */* and */admin*.
 
-
 ## Build
 
 ### Docker images
+
 ```bash
 docker buildx create --use --name=cross
 docker buildx build --platform=linux/amd64,linux/arm64,linux/arm/v5,linux/arm/v6,linux/arm/v7,darwin/amd64,darwin/arm64,windows/amd64 .

--- a/auth.go
+++ b/auth.go
@@ -35,7 +35,7 @@ func authMiddleware(next http.Handler) http.Handler {
 }
 
 func parseAuth(auth string) {
-	identity := strings.Split(*setBasicAuth, ":")
+	identity := strings.Split(auth, ":")
 	if len(identity) != 2 {
 		log.Fatalln("basic auth must be like this: user:password")
 	}

--- a/fallback.go
+++ b/fallback.go
@@ -14,8 +14,8 @@ type fallback struct {
 
 func OpenDefault(fb fallback, requestPath string) (http.File, error) {
 	requestPath = path.Dir(requestPath)
-	defaultFile := requestPath + "/" + fb.defaultPath;
-	
+	defaultFile := requestPath + "/" + fb.defaultPath
+
 	f, err := fb.fs.Open(defaultFile)
 	if os.IsNotExist(err) && requestPath != "" {
 		parentPath, _ := path.Split(requestPath)

--- a/main.go
+++ b/main.go
@@ -35,6 +35,8 @@ var (
 	logRequest               = flag.Bool("enable-logging", false, "Enable log request. NOTE: Deprecated, set log-level to debug to log all requests")
 	httpsPromote             = flag.Bool("https-promote", false, "All HTTP requests should be redirected to HTTPS")
 	headerConfigPath         = flag.String("header-config-path", "/config/headerConfig.json", "Path to the config file for custom response headers")
+	basicAuthUser            = flag.String("basic-auth-user", "", "Username for basic auth")
+	basicAuthPass            = flag.String("basic-auth-pass", "", "Password for basic auth")
 
 	username string
 	password string
@@ -159,7 +161,9 @@ func main() {
 
 	if *basicAuth {
 		log.Debug().Msg("Enabling Basic Auth")
-		if len(*setBasicAuth) != 0 {
+		if len(*basicAuthUser) != 0 && len(*basicAuthPass) != 0 {
+			parseAuth(*basicAuthUser + ":" + *basicAuthPass)
+		} else if len(*setBasicAuth) != 0 {
 			parseAuth(*setBasicAuth)
 		} else {
 			generateRandomAuth()


### PR DESCRIPTION
I'm aware there's currently a `setBasicAuth` flag, however I spent multiple hours troubleshooting the ENTRYPOINT command I was using (it was calling `/bin/sh -c` when I tried to pass my user:pass string in as part of a flag).

This should enable some better support for weird username and password combinations when setting basic auth. The more ideal solution would be consuming environment variables, so that we can consume those variables at runtime and not require modifications or secret injection at build time.

The specific use-case I was having trouble with was injecting my password at runtime via Fly.io, and using a password that needed to be encapsulated in commas. There may have been a better way to solve it, but more flags don't hurt, right?

Also formatted the docs a bit.